### PR TITLE
New Command: Update Dotnet Templates

### DIFF
--- a/src/NuGetPackageSearchCmdPalExtension/NuGetPackageSearchCmdPalExtensionCommandsProvider.cs
+++ b/src/NuGetPackageSearchCmdPalExtension/NuGetPackageSearchCmdPalExtensionCommandsProvider.cs
@@ -18,6 +18,7 @@ public partial class NuGetPackageSearchCmdPalExtensionCommandsProvider : Command
         _commands = [
             new CommandItem(new Pages.SearchNuGetPackagesPage()) { Title = "Search NuGet Packages" },
             new CommandItem(new Pages.SearchDotnetTemplatesPage()) {Title = "Search Dotnet Templates"},
+            new CommandItem(new Pages.UpdateDotnetTemplatesPage()) {Title = "Update Dotnet Templates"},
             new CommandItem(new Pages.SearchDotnetToolsPage()){Title = "Search Dotnet Tools"}
         ];
     }

--- a/src/NuGetPackageSearchCmdPalExtension/Package.appxmanifest
+++ b/src/NuGetPackageSearchCmdPalExtension/Package.appxmanifest
@@ -12,7 +12,7 @@
   <Identity
     Name="23610AlickolliSoftware.NuGetPackageSearchforComman"
     Publisher="CN=5CECD841-CF4E-45AF-B443-573F4A3614A0"
-    Version="0.0.4.0" />
+    Version="0.0.5.0" />
   <!-- When you're ready to publish your extension, you'll need to change the
        Publisher= to match your own identity -->
 

--- a/src/NuGetPackageSearchCmdPalExtension/Pages/UpdateDotnetTemplatesPage.cs
+++ b/src/NuGetPackageSearchCmdPalExtension/Pages/UpdateDotnetTemplatesPage.cs
@@ -163,7 +163,7 @@ namespace NuGetPackageSearchCmdPalExtension.Pages
                     StartInfo = new ProcessStartInfo
                     {
                         FileName = "dotnet",
-                        Arguments = "new update --force",
+                        Arguments = "new update",
                         RedirectStandardOutput = true,
                         RedirectStandardError = true,
                         UseShellExecute = false,

--- a/src/NuGetPackageSearchCmdPalExtension/Pages/UpdateDotnetTemplatesPage.cs
+++ b/src/NuGetPackageSearchCmdPalExtension/Pages/UpdateDotnetTemplatesPage.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Windows.ApplicationModel;
 
@@ -97,9 +98,14 @@ namespace NuGetPackageSearchCmdPalExtension.Pages
                                     Icon = new IconInfo("\uE896")
                                 },
                                 MoreCommands = [
-                                    new CommandContextItem("Update All Templates",name:"Update All Templates", action: UpdateAllTemplates())
+                                    new CommandContextItem(
+                                        "Update All Templates",
+                                        name:"Update All Templates",
+                                        action: UpdateAllTemplates(),
+                                        result:CommandResult.GoHome()
+                                    )
                                     {
-                                        Icon = new IconInfo("\uE896")
+                                        Icon = new IconInfo("\uE896"),
                                     }
                                 ]
                             });
@@ -137,6 +143,9 @@ namespace NuGetPackageSearchCmdPalExtension.Pages
         {
             return () =>
             {
+                var toast = new ToastStatusMessage($"Updating Template: {packageName} to {version}");
+                toast.Show();
+                Thread.Sleep(TimeSpan.FromSeconds(5));
                 var process = new Process
                 {
                     StartInfo = new ProcessStartInfo
@@ -158,6 +167,9 @@ namespace NuGetPackageSearchCmdPalExtension.Pages
         {
             return () =>
             {
+                var toast = new ToastStatusMessage("Updating All Dotnet Templates");
+                toast.Show();
+                Thread.Sleep(TimeSpan.FromSeconds(5));
                 var process = new Process
                 {
                     StartInfo = new ProcessStartInfo

--- a/src/NuGetPackageSearchCmdPalExtension/Pages/UpdateDotnetTemplatesPage.cs
+++ b/src/NuGetPackageSearchCmdPalExtension/Pages/UpdateDotnetTemplatesPage.cs
@@ -1,0 +1,178 @@
+﻿using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.ApplicationModel;
+
+namespace NuGetPackageSearchCmdPalExtension.Pages
+{
+    internal sealed partial class UpdateDotnetTemplatesPage : ListPage
+    {
+        public UpdateDotnetTemplatesPage()
+        {
+            // Retrieve the app version
+            var version = Package.Current.Id.Version;
+            var appVersion = $"{version.Major}.{version.Minor}.{version.Build}.{version.Revision}";
+
+            Icon = new IconInfo("\uE773");
+            Title = $"NuGet Package Search Extension - v{appVersion}";
+            Name = "Update";
+        }
+
+        public override IListItem[] GetItems()
+        {
+            var items = new List<IListItem>();
+
+            try
+            {
+                var process = new Process
+                {
+                    StartInfo = new ProcessStartInfo
+                    {
+                        FileName = "dotnet",
+                        Arguments = "new update --check-only",
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true,
+                        UseShellExecute = false,
+                        CreateNoWindow = true
+                    }
+                };
+
+                process.Start();
+                string output = process.StandardOutput.ReadToEnd();
+                string error = process.StandardError.ReadToEnd();
+                process.WaitForExit();
+
+                Debug.WriteLine("dotnet new update --check-only output:");
+                Debug.WriteLine(output);
+                if (!string.IsNullOrWhiteSpace(error))
+                {
+                    Debug.WriteLine("dotnet new update --check-only error:");
+                    Debug.WriteLine(error);
+                }
+
+                // Parse the table section
+                var lines = output.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+                int tableStart = -1;
+                for (int i = 0; i < lines.Length; i++)
+                {
+                    if (lines[i].Trim().StartsWith("Package", StringComparison.Ordinal) &&
+                        lines[i].Contains("Current") && lines[i].Contains("Latest"))
+                    {
+                        tableStart = i + 2; // Skip header and separator
+                        break;
+                    }
+                }
+
+                if (tableStart != -1)
+                {
+                    for (int i = tableStart; i < lines.Length; i++)
+                    {
+                        var line = lines[i];
+                        if (string.IsNullOrWhiteSpace(line) ||
+                            line.StartsWith("To update the package use:", StringComparison.Ordinal) ||
+                            line.StartsWith("To update all the packages use:", StringComparison.Ordinal))
+                            break;
+
+                        // Split by whitespace, but only for the first 3 columns
+                        var parts = line.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                        if (parts.Length >= 3)
+                        {
+                            var package = parts[0];
+                            var current = parts[1];
+                            var latest = parts[2];
+
+                            items.Add(new ListItem
+                            {
+                                Title = package,
+                                Subtitle = $"Current: {current} → Latest: {latest}",
+                                Icon = new IconInfo("\uE7B8"),
+                                Command = new AnonymousCommand(UpdateTemplate(package, latest))
+                                {
+                                    Name = "Update Template",
+                                    Icon = new IconInfo("\uE896")
+                                },
+                                MoreCommands = [
+                                    new CommandContextItem("Update All Templates",name:"Update All Templates", action: UpdateAllTemplates())
+                                    {
+                                        Icon = new IconInfo("\uE896")
+                                    }
+                                ]
+                            });
+                        }
+                    }
+                }
+
+                if (items.Count == 0)
+                {
+                    items.Add(new ListItem
+                    {
+                        Title = "No template updates available.",
+                        Icon = new IconInfo("\uE8FB"),
+                        Command = new NoOpCommand()
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine("Exception in GetItems: " + ex);
+
+                items.Add(new ListItem
+                {
+                    Title = "Error checking for template updates",
+                    Subtitle = ex.Message,
+                    Icon = new IconInfo("\uEA39"),
+                    Command = new NoOpCommand()
+                });
+            }
+
+            return [.. items];
+        }
+
+        public static Action UpdateTemplate(string packageName, string version)
+        {
+            return () =>
+            {
+                var process = new Process
+                {
+                    StartInfo = new ProcessStartInfo
+                    {
+                        FileName = "dotnet",
+                        Arguments = $"new install {packageName}::{version} --force",
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true,
+                        UseShellExecute = false,
+                        CreateNoWindow = false
+                    }
+                };
+                process.Start();
+                process.WaitForExit();
+            };
+        }
+
+        public static Action UpdateAllTemplates()
+        {
+            return () =>
+            {
+                var process = new Process
+                {
+                    StartInfo = new ProcessStartInfo
+                    {
+                        FileName = "dotnet",
+                        Arguments = "new update --force",
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true,
+                        UseShellExecute = false,
+                        CreateNoWindow = false
+                    }
+                };
+                process.Start();
+                process.WaitForExit();
+            };
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new feature to the `NuGetPackageSearchCmdPalExtension` by adding support for updating .NET templates directly from the command palette. It also includes a version bump for the extension. Below are the key changes:

### New Feature: Update .NET Templates

* Added a new page `UpdateDotnetTemplatesPage` that allows users to check for and update .NET templates. This includes:
  - Parsing the output of `dotnet new update --check-only` to display available updates.
  - Providing commands to update individual templates or all templates at once. (`src/NuGetPackageSearchCmdPalExtension/Pages/UpdateDotnetTemplatesPage.cs`)
* Integrated the new page into the command palette by adding it to the `_commands` list in `NuGetPackageSearchCmdPalExtensionCommandsProvider`. (`src/NuGetPackageSearchCmdPalExtension/NuGetPackageSearchCmdPalExtensionCommandsProvider.cs`)

### Version Update

* Updated the extension version from `0.0.4.0` to `0.0.5.0` in the `Package.appxmanifest` file to reflect the new feature addition. (`src/NuGetPackageSearchCmdPalExtension/Package.appxmanifest`)