### PR TITLE
Added Command "Open In NuGet Gallery" to each page

### DIFF
--- a/src/NuGetPackageSearchCmdPalExtension/Pages/SearchDotnetTemplatesPage.cs
+++ b/src/NuGetPackageSearchCmdPalExtension/Pages/SearchDotnetTemplatesPage.cs
@@ -148,7 +148,8 @@ namespace NuGetPackageSearchCmdPalExtension.Pages
                             process.StartInfo = startInfo;
                             process.Start();
                             process.WaitForExit();
-                        }){Icon = new IconInfo("\uE896"), Name = "Install Template"})
+                        }){Icon = new IconInfo("\uE896"), Name = "Install Template"}),
+                        new CommandContextItem(new OpenUrlCommand($"https://www.nuget.org/packages/{id}"){Name = "Open in NuGet Gallery"})
                     ]
                 });
             }

--- a/src/NuGetPackageSearchCmdPalExtension/Pages/SearchDotnetToolsPage.cs
+++ b/src/NuGetPackageSearchCmdPalExtension/Pages/SearchDotnetToolsPage.cs
@@ -151,8 +151,8 @@ namespace NuGetPackageSearchCmdPalExtension.Pages
                         }){Icon = new IconInfo("\uE896"), Name = "Install tool globally"}),
                         new CommandContextItem(new CopyTextCommand($"dotnet tool install --local {id} --version {version}"){Name = "Copy local install command"}),
                         new CommandContextItem(new CopyTextCommand($"#tool dotnet:?package={id}&version={version}"){Name = "Copy cake tool"}),
-                        new CommandContextItem(new CopyTextCommand($"nuke :add-package {id} --version {version}"){Name = "Copy NUKE"})
-
+                        new CommandContextItem(new CopyTextCommand($"nuke :add-package {id} --version {version}"){Name = "Copy NUKE"}),
+                        new CommandContextItem(new OpenUrlCommand($"https://www.nuget.org/packages/{id}"){Name = "Open in NuGet Gallery"})
                     ]
                 });
             }

--- a/src/NuGetPackageSearchCmdPalExtension/Pages/SearchMCPServerPage.cs
+++ b/src/NuGetPackageSearchCmdPalExtension/Pages/SearchMCPServerPage.cs
@@ -163,7 +163,8 @@ namespace NuGetPackageSearchCmdPalExtension.Pages
                                                                      }
                                                                      """)
                             {Name = "Copy MCP Server"}
-                        )
+                        ),
+                        new CommandContextItem(new OpenUrlCommand($"https://www.nuget.org/packages/{id}"){Name = "Open in NuGet Gallery"})
                     ]
                 });
             }

--- a/src/NuGetPackageSearchCmdPalExtension/Pages/SearchNuGetPackagesPage.cs
+++ b/src/NuGetPackageSearchCmdPalExtension/Pages/SearchNuGetPackagesPage.cs
@@ -142,7 +142,8 @@ internal sealed partial class SearchNuGetPackagesPage : DynamicListPage, IDispos
                     new CommandContextItem(new CopyTextCommand($"#r \"nuget: {id}, {version}\""){Name = "Copy Script & Interactive"}),
                     new CommandContextItem(new CopyTextCommand($"#:package {id}@{version}"){Name = "Copy File-based Apps"}),
                     new CommandContextItem(new CopyTextCommand($"#addin nuget:?package={id}={version}"){Name = "Copy Cake Addin"}),
-                    new CommandContextItem(new CopyTextCommand($"#tool nuget:?package={id}&version={version}"){Name = "Copy Cake Tool"})
+                    new CommandContextItem(new CopyTextCommand($"#tool nuget:?package={id}&version={version}"){Name = "Copy Cake Tool"}),
+                    new CommandContextItem(new OpenUrlCommand($"https://www.nuget.org/packages/{id}"){Name = "Open in NuGet Gallery"})
 
                 ]
             });


### PR DESCRIPTION
This pull request adds a new feature across multiple search pages in the NuGet Package Search CmdPal Extension: the ability for users to quickly open the NuGet Gallery page for any package or template directly from the search results. This enhancement improves user accessibility and workflow by providing a convenient link to package details.

New "Open in NuGet Gallery" command:

* Added a `CommandContextItem` using `OpenUrlCommand` to open the NuGet Gallery page for the selected package or template in the following search pages:
  * `SearchNuGetPackagesPage.cs` – Users can now open the NuGet Gallery for NuGet packages.
  * `SearchDotnetTemplatesPage.cs` – Users can now open the NuGet Gallery for .NET templates.
  * `SearchDotnetToolsPage.cs` – Users can now open the NuGet Gallery for .NET tools.
  * `SearchMCPServerPage.cs` – Users can now open the NuGet Gallery for MCP Server packages.

Resolves #5 