### PR TITLE
Added dnx copy to dotnet tools

### DIFF
--- a/src/NuGetPackageSearchCmdPalExtension/Pages/SearchDotnetToolsPage.cs
+++ b/src/NuGetPackageSearchCmdPalExtension/Pages/SearchDotnetToolsPage.cs
@@ -152,6 +152,7 @@ namespace NuGetPackageSearchCmdPalExtension.Pages
                         new CommandContextItem(new CopyTextCommand($"dotnet tool install --local {id} --version {version}"){Name = "Copy local install command"}),
                         new CommandContextItem(new CopyTextCommand($"#tool dotnet:?package={id}&version={version}"){Name = "Copy cake tool"}),
                         new CommandContextItem(new CopyTextCommand($"nuke :add-package {id} --version {version}"){Name = "Copy NUKE"}),
+                        new CommandContextItem(new CopyTextCommand($"dnx {id} --version {version}"){Name = "Copy dnx"}),
                         new CommandContextItem(new OpenUrlCommand($"https://www.nuget.org/packages/{id}"){Name = "Open in NuGet Gallery"})
                     ]
                 });


### PR DESCRIPTION
This pull request introduces a small enhancement to the `SearchDotnetToolsPage` by adding a new command context item to the list of available actions for each tool.

- User experience improvement:
  * Added a new "Copy dnx" command to the list of context actions, allowing users to quickly copy a `dnx` installation command for a given package and version.